### PR TITLE
Bing link broke

### DIFF
--- a/potd.py
+++ b/potd.py
@@ -147,12 +147,12 @@ def getBingLink(out_file):
     r = requests.get('http://www.bing.com')    
     if(r.status_code != 200):
         print("ERROR: status_code: "+r.status_code)
-        sys.exit()    
+        sys.exit()
     #get text
     cont = r.text
     to_find = "g_img={url:"
     pos = cont.find(to_find)
-    pos2 = cont.find(",",pos)
+    pos2 = min(cont.find(",",pos),  cont.find("};",pos))
     link = cont[pos+len(to_find)+1:pos2].replace('"','').replace("'","")
     img_link = "http://www.bing.com"+link
     downloadFile(img_link, out_file)


### PR DESCRIPTION
Bing link broke, giving me a very long `img_link`.  I think due to a single image being on their webpage.

I think your code was expecting:
`g_img{url:img_url1,img_url2};`
In the case of a single image we get:
`g_img={url:img_url1};`
If this is right.  Then the solution would be for `pos2` to be a minimum of `,` and `};`.
`pos2 = min(cont.find(",",pos),  cont.find("};",pos))`

Hopefully I've understood the problem correctly.